### PR TITLE
Fix: prefix modulePackageName with suitcss-

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -65,7 +65,7 @@ module.exports = yeoman.generators.Base.extend({
       // Utilities
       if (props.moduleType === 'utility') {
         this.props.moduleCssName = 'u-' + toCamelCase(this.moduleName);
-        this.props.modulePackageName = 'utils-' + this.moduleName;
+        this.props.modulePackageName = 'suitcss-utils-' + this.moduleName;
         this.props.moduleDescription = props.moduleDescription ?
           props.moduleDescription + ' utilities for SUIT CSS':
           '';
@@ -75,7 +75,7 @@ module.exports = yeoman.generators.Base.extend({
 
       // Components
       this.props.moduleCssName = toPascalCase(this.moduleName);
-      this.props.modulePackageName = 'components-' + this.moduleName;
+      this.props.modulePackageName = 'suitcss-components-' + this.moduleName;
       this.props.moduleDescription = props.moduleDescription ?
         'A SUIT component for ' + props.moduleDescription :
         '';

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -8,7 +8,7 @@ Read more about [SUIT's design principles](https://github.com/suitcss/suit/).
 
 ## Installation
 
-* [npm](https://npmjs.org/): `npm install suitcss-<%= modulePackageName %>`
+* [npm](https://npmjs.org/): `npm install <%= modulePackageName %>`
 * Download: [releases](https://github.com/<%= moduleAuthorGithubUsername %>/<%= modulePackageName %>/releases/latest)
 
 ## Available classes

--- a/generators/app/templates/packagejson
+++ b/generators/app/templates/packagejson
@@ -1,5 +1,5 @@
 {
-  "name": "suitcss-<%= modulePackageName %>",
+  "name": "<%= modulePackageName %>",
   "description": "<%= moduleDescription %>",
   "version": "0.0.0",
   "style": "index.css",


### PR DESCRIPTION
Initially the `modulePackageName` didn't include `suitcss-` because it is redundant for packages hosted under the `suitcss` org. However it is needed for 3rd parties packages – I found myself fixing this all the times. 